### PR TITLE
feat: Implement en passant and castling rules in chess game

### DIFF
--- a/lib/core/models/chess_piece.dart
+++ b/lib/core/models/chess_piece.dart
@@ -93,9 +93,7 @@ class Pawn extends ChessPiece {
           }
         }
       }
-    }
-
-    // Diagonal captures
+    } // Diagonal captures
     for (final deltaCol in [-1, 1]) {
       final capturePos =
           Position(position.col + deltaCol, position.row + direction);
@@ -107,6 +105,36 @@ class Pawn extends ChessPiece {
             pieces.where((p) => p.position == capturePos).firstOrNull;
         if (targetPiece != null && targetPiece.color != color) {
           moves.add(capturePos);
+        }
+      }
+    }
+
+    // En passant moves
+    // Check if this pawn is in the correct position for en passant (5th rank for white, 4th rank for black)
+    final enPassantRow = color == PieceColor.white ? 3 : 4;
+    if (position.row == enPassantRow) {
+      for (final deltaCol in [-1, 1]) {
+        final adjacentPos = Position(position.col + deltaCol, position.row);
+        final enPassantCapturePos =
+            Position(position.col + deltaCol, position.row + direction);
+
+        // Check if the adjacent position contains an enemy pawn
+        final adjacentPiece =
+            pieces.where((p) => p.position == adjacentPos).firstOrNull;
+        if (adjacentPiece != null &&
+            adjacentPiece.color != color &&
+            adjacentPiece.type == PieceType.pawn &&
+            enPassantCapturePos.col >= 0 &&
+            enPassantCapturePos.col < 8 &&
+            enPassantCapturePos.row >= 0 &&
+            enPassantCapturePos.row < 8) {
+          // The en passant capture square should be empty
+          final captureSquareEmpty =
+              !pieces.any((p) => p.position == enPassantCapturePos);
+          if (captureSquareEmpty) {
+            // Add this as a potential en passant move - the validator will check if it's valid
+            moves.add(enPassantCapturePos);
+          }
         }
       }
     }
@@ -458,6 +486,25 @@ class King extends ChessPiece {
             pieces.where((p) => p.position == newPos).firstOrNull;
         if (pieceAtPos == null || pieceAtPos.color != color) {
           moves.add(newPos);
+        }
+      }
+    }
+
+    // Castling moves - add potential castling squares
+    // The validator will check if castling is actually legal
+    if (!hasMoved) {
+      final expectedRow = color == PieceColor.white ? 7 : 0;
+      if (position.row == expectedRow && position.col == 4) {
+        // King side castling (O-O)
+        final kingSideCastlePos = Position(6, expectedRow);
+        if (kingSideCastlePos.col >= 0 && kingSideCastlePos.col < 8) {
+          moves.add(kingSideCastlePos);
+        }
+
+        // Queen side castling (O-O-O)
+        final queenSideCastlePos = Position(2, expectedRow);
+        if (queenSideCastlePos.col >= 0 && queenSideCastlePos.col < 8) {
+          moves.add(queenSideCastlePos);
         }
       }
     }

--- a/lib/core/models/position.dart
+++ b/lib/core/models/position.dart
@@ -23,6 +23,9 @@ class Position {
     return '$file$rank';
   }
 
+  @override
+  String toString() => algebraic;
+
   // Add row/col getters for compatibility with other code in the codebase
   int get row => y;
   int get col => x;

--- a/lib/presentation/game_room/bloc/game_room_event.dart
+++ b/lib/presentation/game_room/bloc/game_room_event.dart
@@ -101,3 +101,22 @@ class TimeoutEvent extends GameRoomEvent {
   final PieceColor timeoutColor; // which player ran out of time
   TimeoutEvent({required this.timeoutColor});
 }
+
+// Promotion dialog events
+class ShowPromotionDialogEvent extends GameRoomEvent {
+  final Position from;
+  final Position to;
+  final ChessPiece pawn;
+
+  ShowPromotionDialogEvent({
+    required this.from,
+    required this.to,
+    required this.pawn,
+  });
+}
+
+class SelectPromotionPieceEvent extends GameRoomEvent {
+  final PieceType pieceType;
+
+  SelectPromotionPieceEvent({required this.pieceType});
+}

--- a/lib/presentation/game_room/bloc/game_room_state.dart
+++ b/lib/presentation/game_room/bloc/game_room_state.dart
@@ -57,14 +57,18 @@ class GameRoomState extends Equatable {
   final bool isBlackKingInCheck;
   // Attacking pieces positions
   final List<Position> whiteAttackingPieces;
-  final List<Position> blackAttackingPieces;
-  // Timer and clock state
+  final List<Position> blackAttackingPieces; // Timer and clock state
   final int whiteTimeLeft; // in seconds
   final int blackTimeLeft; // in seconds
   final bool timerRunning;
   final bool timerPaused;
   final PieceColor?
       activeTimerColor; // which player's timer is currently running
+  // Promotion dialog state
+  final bool showingPromotionDialog;
+  final Position? promotionFromPosition;
+  final Position? promotionToPosition;
+  final ChessPiece? promotionPawn;
 
   const GameRoomState({
     this.gameRoom,
@@ -100,6 +104,11 @@ class GameRoomState extends Equatable {
     this.lastDoubleMovePawn,
     this.moveNumber = 1,
     this.positionHistory = const [],
+    // Promotion dialog state
+    this.showingPromotionDialog = false,
+    this.promotionFromPosition,
+    this.promotionToPosition,
+    this.promotionPawn,
   });
 
   GameRoomState copyWith({
@@ -136,10 +145,16 @@ class GameRoomState extends Equatable {
     String? lastDoubleMovePawn,
     int? moveNumber,
     List<String>? positionHistory,
+    // Promotion dialog state
+    bool? showingPromotionDialog,
+    Position? promotionFromPosition,
+    Position? promotionToPosition,
+    ChessPiece? promotionPawn,
     bool clearSelectedPosition = false,
     bool clearAnimatingMove = false,
     bool clearHint = false,
     bool clearLastDoubleMovePawn = false,
+    bool clearPromotionDialog = false,
   }) {
     return GameRoomState(
       gameRoom: gameRoom ?? this.gameRoom,
@@ -182,6 +197,18 @@ class GameRoomState extends Equatable {
           : (lastDoubleMovePawn ?? this.lastDoubleMovePawn),
       moveNumber: moveNumber ?? this.moveNumber,
       positionHistory: positionHistory ?? this.positionHistory,
+      // Promotion dialog state
+      showingPromotionDialog: clearPromotionDialog
+          ? false
+          : (showingPromotionDialog ?? this.showingPromotionDialog),
+      promotionFromPosition: clearPromotionDialog
+          ? null
+          : (promotionFromPosition ?? this.promotionFromPosition),
+      promotionToPosition: clearPromotionDialog
+          ? null
+          : (promotionToPosition ?? this.promotionToPosition),
+      promotionPawn:
+          clearPromotionDialog ? null : (promotionPawn ?? this.promotionPawn),
     );
   }
 
@@ -216,9 +243,13 @@ class GameRoomState extends Equatable {
         activeTimerColor,
         // Enhanced game state for FIDE rules
         pgnMoveHistory,
-        fiftyMoveCounter,
-        lastDoubleMovePawn,
+        fiftyMoveCounter, lastDoubleMovePawn,
         moveNumber,
         positionHistory,
+        // Promotion dialog state
+        showingPromotionDialog,
+        promotionFromPosition,
+        promotionToPosition,
+        promotionPawn,
       ];
 }

--- a/lib/presentation/game_room/command/en_passant_command.dart
+++ b/lib/presentation/game_room/command/en_passant_command.dart
@@ -1,0 +1,57 @@
+import 'package:chess_game/core/models/chess_piece.dart';
+import 'package:chess_game/core/models/position.dart';
+import 'package:chess_game/presentation/game_room/command/command.dart';
+import 'package:chess_game/presentation/game_room/memento/chess_board_manager.dart';
+
+/// Command cho nước đi bắt tốt qua đường (en passant)
+class EnPassantCommand implements Command {
+  final ChessPiece pawn;
+  final Position from;
+  final Position to;
+  final ChessPiece capturedPawn;
+  final Position capturedPawnPosition;
+  final ChessBoardManager? boardManager;
+  late final Position oldPawnPosition;
+
+  EnPassantCommand({
+    required this.pawn,
+    required this.from,
+    required this.to,
+    required this.capturedPawn,
+    required this.capturedPawnPosition,
+    this.boardManager,
+  }) {
+    oldPawnPosition = pawn.position.clone();
+  }
+
+  @override
+  void execute() {
+    if (boardManager != null) {
+      // Di chuyển tốt
+      boardManager!.movePiece(from, to);
+      // Xóa tốt bị bắt qua đường
+      boardManager!.setPieceAt(capturedPawnPosition, null);
+    } else {
+      pawn.position = to;
+      // Nếu không có boardManager, cần xử lý xóa capturedPawn khỏi board thủ công
+    }
+  }
+
+  @override
+  void undo() {
+    if (boardManager != null) {
+      // Trả lại tốt bị bắt qua đường
+      boardManager!.setPieceAt(capturedPawnPosition, capturedPawn);
+      // Trả lại tốt về vị trí cũ
+      boardManager!.movePiece(to, from);
+    } else {
+      pawn.position = oldPawnPosition;
+      // Nếu không có boardManager, cần xử lý thêm lại capturedPawn thủ công
+    }
+  }
+
+  @override
+  void redo() {
+    execute();
+  }
+}

--- a/lib/presentation/game_room/command/game_room_command_manager.dart
+++ b/lib/presentation/game_room/command/game_room_command_manager.dart
@@ -6,6 +6,7 @@ import 'package:chess_game/presentation/game_room/command/ai_move_command.dart';
 import 'package:chess_game/presentation/game_room/command/castle_command.dart';
 import 'package:chess_game/presentation/game_room/command/promote_command.dart';
 import 'package:chess_game/presentation/game_room/memento/chess_board_manager.dart';
+import 'package:chess_game/presentation/game_room/command/en_passant_command.dart';
 
 /// Game Room Command Manager that integrates Command pattern with Memento pattern
 /// This class handles all chess game commands and automatically saves board state
@@ -46,7 +47,9 @@ class GameRoomCommandManager {
   bool _shouldSaveState(Command command) {
     // Don't auto-save for MoveCommand and AIMoveCommand as they're handled manually in the bloc
     // to ensure proper turn synchronization
-    return command is CastleCommand || command is PromoteCommand;
+    return command is CastleCommand ||
+        command is PromoteCommand ||
+        command is EnPassantCommand;
   }
 
   void undo() {
@@ -133,6 +136,25 @@ class GameRoomCommandManager {
       newPiece: newPiece,
       oldPiece: oldPiece,
       newPosition: newPosition,
+      boardManager: _boardManager,
+    );
+    executeCommand(command);
+  }
+
+  /// Execute en passant command
+  void executeEnPassant({
+    required ChessPiece pawn,
+    required Position from,
+    required Position to,
+    required ChessPiece capturedPawn,
+    required Position capturedPawnPosition,
+  }) {
+    final command = EnPassantCommand(
+      pawn: pawn,
+      from: from,
+      to: to,
+      capturedPawn: capturedPawn,
+      capturedPawnPosition: capturedPawnPosition,
       boardManager: _boardManager,
     );
     executeCommand(command);

--- a/lib/presentation/game_room/widgets/promotion_dialog.dart
+++ b/lib/presentation/game_room/widgets/promotion_dialog.dart
@@ -1,0 +1,146 @@
+import 'package:chess_game/core/common/text/common_text.dart';
+import 'package:chess_game/core/models/chess_piece.dart';
+import 'package:chess_game/di/injection.dart';
+import 'package:chess_game/theme/app_theme.dart';
+import 'package:chess_game/theme/font/app_font_size.dart';
+import 'package:chess_game/theme/font/app_font_weight.dart';
+import 'package:chess_game/theme/spacing/app_spacing.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// A dialog that allows the player to choose which piece to promote a pawn to.
+class PromotionDialog extends StatelessWidget {
+  /// The color of the pawn being promoted
+  final PieceColor pawnColor;
+
+  /// Callback when a piece type is selected
+  final void Function(PieceType) onPieceSelected;
+
+  PromotionDialog({
+    required this.pawnColor,
+    required this.onPieceSelected,
+    super.key,
+  });
+
+  final _themeColor = getIt.get<AppTheme>().themeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: _themeColor.backgroundColor,
+      title: CommonText(
+        'Promote Pawn',
+        style: TextStyle(
+          fontSize: AppFontSize.lg,
+          fontWeight: AppFontWeight.bold,
+          color: _themeColor.textPrimaryColor,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CommonText(
+            'Choose which piece to promote to:',
+            style: TextStyle(
+              fontSize: AppFontSize.md,
+              color: _themeColor.textPrimaryColor,
+            ),
+          ),
+          SizedBox(height: AppSpacing.rem300),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _buildPieceOption(PieceType.queen),
+              _buildPieceOption(PieceType.rook),
+              _buildPieceOption(PieceType.bishop),
+              _buildPieceOption(PieceType.knight),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPieceOption(PieceType pieceType) {
+    final pieceIcon = _getPieceIcon(pieceType, pawnColor);
+    final pieceName = _getPieceName(pieceType);
+
+    return GestureDetector(
+      onTap: () => onPieceSelected(pieceType),
+      child: Container(
+        width: 60,
+        height: 80,
+        padding: EdgeInsets.all(AppSpacing.rem100),
+        decoration: BoxDecoration(
+          color: _themeColor.surfaceColor,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: _themeColor.primaryColor.withOpacity(0.3),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 4,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 36,
+              height: 36,
+              child: SvgPicture.asset(
+                pieceIcon,
+                fit: BoxFit.contain,
+              ),
+            ),
+            SizedBox(height: AppSpacing.rem050),
+            CommonText(
+              pieceName,
+              style: TextStyle(
+                fontSize: AppFontSize.xs,
+                fontWeight: AppFontWeight.medium,
+                color: _themeColor.textPrimaryColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getPieceIcon(PieceType pieceType, PieceColor color) {
+    final colorSuffix = color == PieceColor.white ? 'white' : 'black';
+
+    switch (pieceType) {
+      case PieceType.queen:
+        return 'assets/icons/queen_$colorSuffix.svg';
+      case PieceType.rook:
+        return 'assets/icons/rook_$colorSuffix.svg';
+      case PieceType.bishop:
+        return 'assets/icons/bishop_$colorSuffix.svg';
+      case PieceType.knight:
+        return 'assets/icons/knight_$colorSuffix.svg';
+      default:
+        return 'assets/icons/queen_$colorSuffix.svg';
+    }
+  }
+
+  String _getPieceName(PieceType pieceType) {
+    switch (pieceType) {
+      case PieceType.queen:
+        return 'Queen';
+      case PieceType.rook:
+        return 'Rook';
+      case PieceType.bishop:
+        return 'Bishop';
+      case PieceType.knight:
+        return 'Knight';
+      default:
+        return 'Queen';
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   bloc:
     dependency: transitive
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -444,10 +444,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
- Added en passant move logic in the Pawn class, allowing pawns to capture adjacent enemy pawns that have moved two squares forward.
- Introduced castling move logic in the King class, enabling king-side and queen-side castling.
- Enhanced move validation to accommodate en passant and castling rules.
- Created a new EnPassantCommand to handle en passant moves and integrated it into the command manager.
- Added promotion dialog functionality, allowing players to choose a piece type when a pawn is promoted.
- Updated GameRoomBloc to manage promotion events and state.
- Implemented a PromotionDialog widget for user interaction during pawn promotion.
- Updated the game state to reflect changes in promotion and en passant moves.
- Adjusted pubspec.lock to update dependencies.